### PR TITLE
Show course length in feet, computed from GPX

### DIFF
--- a/app/events/[event]/page.tsx
+++ b/app/events/[event]/page.tsx
@@ -4,15 +4,33 @@ import { getEventBySlugWithHeats } from "../../lib/sanity"
 import s from './page.module.css'
 import Map from '../../map/page'
 import { formatDate } from "../../../cms/utils/formatDate"
+import { calculateDistanceFeet, parseGPX } from "../../utils/gpxParser"
+
+async function getComputedLengthFeet(mapUrl?: string | null): Promise<number | null> {
+  if (!mapUrl) return null
+  try {
+    const res = await fetch(mapUrl, { next: { revalidate: 3600 } })
+    if (!res.ok) return null
+    const text = await res.text()
+    const points = parseGPX(text)
+    if (points.length < 2) return null
+    return Math.round(calculateDistanceFeet(points))
+  } catch {
+    return null
+  }
+}
 
 const EventPage = async ({ params }: { params: Promise<{ event: string }> }) => {
   const { event: eventSlug } = await params
   const eventData = await getEventBySlugWithHeats(eventSlug)
-  console.log(eventData)
 
   if (!eventData) {
     return <div>Event not found</div>
   }
+
+  const computedLengthFeet = await getComputedLengthFeet(eventData.mapUrl)
+  const displayLength = computedLengthFeet ?? eventData.length
+
   return (
     <div className={s.eventPage}>
       <div className={s.info}>
@@ -24,7 +42,7 @@ const EventPage = async ({ params }: { params: Promise<{ event: string }> }) => 
         <Map miniMap={true} defaultGpxUrl={eventData.mapUrl || undefined} />
         <div className={s.courseInfo}>
           <h2>Course Info</h2>
-          <p>Length: {eventData.length} feet</p>
+          <p>Length: {typeof displayLength === 'number' ? displayLength.toLocaleString() : displayLength} feet</p>
           <p>Type: {eventData.courseType}</p>
           <p>Difficulty: {eventData.difficulty}</p>
         </div>

--- a/app/map/page.module.css
+++ b/app/map/page.module.css
@@ -160,6 +160,16 @@
   outline: 0;
 }
 
+.lengthValue {
+  color: white;
+  font-size: 14px;
+  padding: 0.5em 1em;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  font-variant-numeric: tabular-nums;
+}
+
 .uploadRow {
   display: flex;
   align-items: center;

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import mapboxgl from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
-import { parseGPX, TrackPoint } from '../utils/gpxParser'
+import { parseGPX, TrackPoint, calculateDistanceFeet } from '../utils/gpxParser'
 import ColorPicker from '../components/ColorPicker'
 import s from './page.module.css'
 import type { GeoJSONSource } from 'mapbox-gl'
@@ -81,6 +81,11 @@ export default function Map({ miniMap, defaultGpxUrl }: { miniMap: boolean, defa
         setLoadingError(message)
       })
   }, [miniMap, defaultGpxUrl])
+
+  const distanceFeet = useMemo(
+    () => (trackPoints.length > 1 ? Math.round(calculateDistanceFeet(trackPoints)) : 0),
+    [trackPoints]
+  )
 
   const buildGradientExpression = () => ([
     'interpolate',
@@ -468,6 +473,12 @@ export default function Map({ miniMap, defaultGpxUrl }: { miniMap: boolean, defa
               onChange={handleUploadGpx}
             />
             <label htmlFor="gpxUpload" className={s.button}>Upload GPX</label>
+          </div>
+          <div className={s.cpSection}>
+            <label>Length</label>
+            <div className={s.lengthValue}>
+              {distanceFeet > 0 ? `${distanceFeet.toLocaleString()} ft` : '—'}
+            </div>
           </div>
           <ColorPicker
             label="Color 1"

--- a/app/utils/gpxParser.ts
+++ b/app/utils/gpxParser.ts
@@ -3,18 +3,45 @@ export interface TrackPoint {
   lon: number;
 }
 
+const TRKPT_REGEX = /<trkpt\b([^>]*)>/gi;
+const LAT_ATTR = /\blat\s*=\s*["']([^"']+)["']/i;
+const LON_ATTR = /\blon\s*=\s*["']([^"']+)["']/i;
+
 export function parseGPX(gpxContent: string): TrackPoint[] {
-  const parser = new DOMParser();
-  const xmlDoc = parser.parseFromString(gpxContent, "text/xml");
   const trackPoints: TrackPoint[] = [];
-
-  const trkpts = xmlDoc.getElementsByTagName("trkpt");
-  for (let i = 0; i < trkpts.length; i++) {
-    const trkpt = trkpts[i];
-    const lat = parseFloat(trkpt.getAttribute("lat") || "0");
-    const lon = parseFloat(trkpt.getAttribute("lon") || "0");
-    trackPoints.push({ lat, lon });
+  let match: RegExpExecArray | null;
+  TRKPT_REGEX.lastIndex = 0;
+  while ((match = TRKPT_REGEX.exec(gpxContent)) !== null) {
+    const attrs = match[1];
+    const lat = attrs.match(LAT_ATTR);
+    const lon = attrs.match(LON_ATTR);
+    if (lat && lon) {
+      trackPoints.push({ lat: parseFloat(lat[1]), lon: parseFloat(lon[1]) });
+    }
   }
-
   return trackPoints;
-} 
+}
+
+const EARTH_RADIUS_METERS = 6371000;
+const METERS_PER_FOOT = 0.3048;
+
+function haversineMeters(a: TrackPoint, b: TrackPoint): number {
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 2 * EARTH_RADIUS_METERS * Math.asin(Math.sqrt(h));
+}
+
+export function calculateDistanceFeet(points: TrackPoint[]): number {
+  if (points.length < 2) return 0;
+  let meters = 0;
+  for (let i = 1; i < points.length; i++) {
+    meters += haversineMeters(points[i - 1], points[i]);
+  }
+  return meters / METERS_PER_FOOT;
+}


### PR DESCRIPTION
## Summary
- Add Haversine-based `calculateDistanceFeet` to `gpxParser` and rewrite `parseGPX` with regex so it works in server components
- Show computed length in the `/map` control panel for the selected GPX
- On the event page, derive length from the uploaded GPX (falling back to the Sanity-entered `length` field) so editors no longer need to hand-enter it

## Test plan
- [ ] `/map`: select different GPX files and confirm the Length row updates with sensible values
- [ ] `/map`: upload a custom GPX and confirm length appears
- [ ] Visit an event page with a GPX attached and confirm the displayed length matches the route
- [ ] Visit an event page without a GPX and confirm it falls back to the Sanity `length` value